### PR TITLE
Fix viewport for mobile devices

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -19,7 +19,6 @@ body {
     color: #e3e3e3;
     font-family: Inconsolata, "Courier New", monospace;
     margin-bottom: 50px;
-    min-width: 740px;
     /* suppose you want minimun width of 740px */
     
     width: auto !important;
@@ -51,10 +50,6 @@ body {
 
 .btn-info {
     background-color: rgb(51, 105, 178);
-}
-
-.footer {
-    min-width: 740px;
 }
 
 .footer > .container {
@@ -109,6 +104,7 @@ a:hover {
 }
 
 .thumbnail {
+    margin: 0 auto;
     padding: 0px 8px;
     max-width: 300px;
     height: 95px;

--- a/source/index.html
+++ b/source/index.html
@@ -78,12 +78,12 @@
             <div class="main-text">
             We kindly thank our sponsors for supporting the PoliCTF:
             <div>
-            <div class="col-xs-6 sponsor">
+            <div class="col-xs-12 col-sm-6 sponsor">
                 <a class="thumbnail" href="http://www.reply.eu/en/topics/security/">
                     <img src="images/sponsor/reply_cv.png" alt="Reply Communication Valley" class="img-responsive" />
                 </a>
             </div>
-            <div class="col-xs-6 sponsor">
+            <div class="col-xs-12 col-sm-6 sponsor">
                 <a class="thumbnail" href="http://www.consorzio-cini.it/index.php/en/">
                     <img src="images/sponsor/cini.png" alt="Consorzio interuniversitario nazionale per l'informatica" class="img-responsive" />
                 </a>


### PR DESCRIPTION
Make all the text and sponsor logos fit in the (single) column of a smartphone.

The animation still requires horizontal scrolling, but at least the countdown is not cut.

Hope this does not break IE and the like.
