### PR TITLE
Use correct font in music and fullscreen buttons

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -35,10 +35,10 @@
         <div class="col-xs-12" id="democanvas"></div>
         <div class="col-xs-12 text-center">
             <button id="player" type="button" class="btn btn-info btn-sm" aria-label="Left Align">
-                <span class="glyphicon glyphicon-play" aria-hidden="true"> Music</span>
+                <span class="glyphicon glyphicon-play" aria-hidden="true"></span>&nbsp;Music
             </button>
             <button type="button" class="btn btn-info btn-sm" aria-label="Left Align" onclick="fullscr('democanvas')">
-                <span class="glyphicon glyphicon-fullscreen" aria-hidden="true"> Fullscreen</span>
+                <span class="glyphicon glyphicon-fullscreen" aria-hidden="true"></span>&nbsp;Fullscreen
             </button>
         </div>
     </div>


### PR DESCRIPTION
Trivial change - Text in buttons using glyphicons should be placed outside the so that the text can use the body font instead of whatever font the current browser wants to use (some browsers use a serif font, that's awful to see...)

This is the real, working PR.
Sorry for having royally messed up before!
