### PR TITLE
Fix width for small screens

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -141,30 +141,34 @@ a:hover {
     bottom: 0;
     width: 100%;
     /* Set the fixed height of the footer here */
-    
     height: 50px;
     background-color: #000;
+}
+
+#democanvas canvas {
+    width: 100%;
+    max-width: 633px;
 }
 
 #democanvas:-moz-full-screen,
 #democanvas:-moz-full-screen canvas {
     background-color: #000000;
-    width: 100%;
     height: 100%;
+    max-width: 100% !important;
 }
 
 #democanvas:-webkit-full-screen,
 #democanvas:-webkit-full-screen canvas {
     background-color: #000000;
-    width: 100%;
     height: 100%;
+    max-width: 100% !important;
 }
 
 #democanvas:fullscreen,
 #democanvas:fullscreen canvas {
     background-color: #000000;
-    width: 100%;
     height: 100%;
+    max-width: 100% !important;
 }
 
 .has-error .form-control {


### PR DESCRIPTION
Specifying the width of the canvas element to 100% makes it resize automatically when the screen width is small (on mobiles), avoiding the nasty effect where the home page seems to be almost black because the logo in the canvas is outside the screen.
I added a max-width so that for medium screens (single column) the canvas has the same width than when the layout is on two columns.
Also the full-screen mode seems to work as it should.

Sorry again for the mess
