### PR TITLE
Do not reload twitter modal

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -42,7 +42,7 @@
                     </li>
                     -->
                     <li>
-                        <a href="javascript:onclick(openmodalnews())">News</a>
+                        <a href="javascript:openmodalnews()">News</a>
                     </li>
                     <li>
                         <a class="nolink" href="#" data-width="600px" data-container="body" data-toggle="popover" data-placement="bottom" data-content="Registration opens on the 15th of May check out later please! :)"><del>Registration</del></a>
@@ -82,8 +82,12 @@
                 $('.nolink').popover('hide');
             }, 5000);
         });
+        news_tweets_loaded = false;
         $("#news_tweets").on('shown.bs.modal', function() {
-            $(this).find(".modal-content").load( "news.html" );
+            if(!news_tweets_loaded) {
+                $(this).find(".modal-content").load( "news.html" );
+                news_tweets_loaded = true;
+            }
         })
         function openmodalnews(){
             $('#news_tweets').modal()

--- a/source/news.html
+++ b/source/news.html
@@ -1,10 +1,2 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title></title>
-</head>
-<body>
 <a class="twitter-timeline" data-dnt="true" href="https://twitter.com/towerofhanoi" data-widget-id="587685771290738688" data-chrome="nofooter noheader noscrollbar transparent" width="500">Tweets by @towerofhanoi</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-</body>
-</html>


### PR DESCRIPTION
Hi ocean,
there is a problem with the twitter timeline. If you close the modal and then reopen it, it will not load the tweets anymore (tweet initialisation is done when loading platform.twitter.com/widgets.js, this is inserted into the DOM by the script loaded on news.html only the first time, so the second time nothing gets executed). Temporarily, this PR will NOT reload the tweets when the modal window is opened again, I have yet to understand how to force a refresh of the tweets on an _existing_ timeline, but IMHO better to have the same tweets than to have an empty modal window.

Btw, there were a couple of issues:
- news.html was an entire html page, this caused <title> and so on to be injected into the DOM as children of the modal window, I removed the structure from the html page so that only the relevant snippet is inserted
- in layout.html, "javascript:onclick(function()) -> javascript:function()", the onclick event was wrong and caused a javascript typeerror to popup on JS console
